### PR TITLE
Replaced calls to deprecated getAdjustmentsTotalByType() method

### DIFF
--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -90,13 +90,13 @@ class Xml extends Component
             ],
             'TaxAmount' => [
                 'callback' => function ($order) {
-                    return $order->getAdjustmentsTotalByType('tax');
+                    return $order->getTotalTax();
                 },
                 'cdata' => false,
             ],
             'ShippingAmount' => [
                 'callback' => function ($order) {
-                    return $order->getAdjustmentsTotalByType('shipping');
+                    return $order->getTotalShippingCost();
                 },
                 'cdata' => false,
             ]
@@ -243,7 +243,7 @@ class Xml extends Component
     public function discount(\SimpleXMLElement $xml, Order $order, $name='Item')
     {
         // If no discount was applied, skip this
-        if ($order->getAdjustmentsTotalByType('discount') >= 0) {
+        if ($order->getTotalDiscount() >= 0) {
             return;
         }
 
@@ -265,7 +265,7 @@ class Xml extends Component
             ],
             'UnitPrice'  => [
                 'callback' => function ($order) {
-                    return number_format($order->getAdjustmentsTotalByType('discount'), 2);
+                    return number_format($order->getTotalDiscount(), 2);
                 },
                 'cdata' => false,
             ],


### PR DESCRIPTION
As of [Commerce 2.2.0](https://github.com/craftcms/commerce/blob/develop/CHANGELOG.md#220---2019-10-23) `craft\commerce\elements\Order::getAdjustmentsTotalByType()` is deprecated. Replaced any calls to this method with the appropriate updated one.