### PR TITLE
Match custom field string length limits to ShipStation limits

### DIFF
--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -440,16 +440,16 @@ class Xml extends Component
     public function customOrderFields(\SimpleXMLElement $order_xml, Order $order)
     {
         $customFields = [
-            OrderFieldEvent::FIELD_CUSTOM_FIELD_1,
-            OrderFieldEvent::FIELD_CUSTOM_FIELD_2,
-            OrderFieldEvent::FIELD_CUSTOM_FIELD_3,
-            OrderFieldEvent::FIELD_INTERNAL_NOTES,
-            OrderFieldEvent::FIELD_CUSTOMER_NOTES,
-            OrderFieldEvent::FIELD_GIFT,
-            OrderFieldEvent::FIELD_GIFT_MESSAGE,
+            [OrderFieldEvent::FIELD_CUSTOM_FIELD_1, 100],
+            [OrderFieldEvent::FIELD_CUSTOM_FIELD_2, 100],
+            [OrderFieldEvent::FIELD_CUSTOM_FIELD_3, 100],
+            [OrderFieldEvent::FIELD_INTERNAL_NOTES, 1000],
+            [OrderFieldEvent::FIELD_CUSTOMER_NOTES, 1000],
+            [OrderFieldEvent::FIELD_GIFT, 100],
+            [OrderFieldEvent::FIELD_GIFT_MESSAGE, 1000],
         ];
 
-        foreach ($customFields as $fieldName) {
+        foreach ($customFields as list($fieldName, $charLimit)) {
             $orderFieldEvent = new OrderFieldEvent([
                 'field' => $fieldName,
                 'order' => $order,
@@ -464,9 +464,9 @@ class Xml extends Component
                 $order_xml->addChild($fieldName, $data);
             } else {
                 if ($orderFieldEvent->cdata) {
-                    $this->addChildWithCDATA($order_xml, $fieldName, substr(htmlspecialchars($data), 0, 100));
+                    $this->addChildWithCDATA($order_xml, $fieldName, substr(htmlspecialchars($data), 0, $charLimit));
                 } else {
-                    $order_xml->addChild($fieldName, substr(htmlspecialchars($data), 0, 100));
+                    $order_xml->addChild($fieldName, substr(htmlspecialchars($data), 0, $charLimit));
                 }
             }
         }


### PR DESCRIPTION
Currently, ShipStation Connect is trimming gift messages, internal notes, and customer notes to 100 characters. However, ShipStation allows up to 1000 characters for those fields (as documented in [Custom Store Reference Guide](https://help.shipstation.com/hc/en-us/articles/360025856192-Custom-Store-Development-Guide#UUID-1bb7ab47-6cf4-c6cd-0e5b-dec61e91201b)). Could length for those fields be extended, maybe something like this?