### PR TITLE
Option to record shipment quantities

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,15 +6,17 @@ use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
 use craft\services\UserPermissions;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\web\twig\variables\CraftVariable;
 use yii\base\Event;
 use yii\base\Exception;
 use fostercommerce\shipstationconnect\web\twig\filters\IsFieldTypeFilter;
+use fostercommerce\shipstationconnect\variables\ShipstationConnectVariable;
 
 class Plugin extends \craft\base\Plugin
 {
     public $hasCpSettings = true;
     public $hasCpSection = true;
-    public $schemaVersion = '1.0.1';
+    public $schemaVersion = '1.1.0';
 
     public function init()
     {
@@ -39,6 +41,11 @@ class Plugin extends \craft\base\Plugin
             $event->permissions['ShipStation Connect'] = [
                 'shipstationconnect-processOrders' => ['label' => 'Process Orders'],
             ];
+        });
+
+        Event::on(CraftVariable::class, CraftVariable::EVENT_INIT, function(Event $event) {
+            $variable = $event->sender;
+            $variable->set('shipstationConnect', ShipstationConnectVariable::class);
         });
     }
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -6,6 +6,7 @@ use craft\web\Controller;
 use craft\elements\MatrixBlock;
 use craft\commerce\Plugin as CommercePlugin;
 use craft\commerce\elements\Order;
+use craft\commerce\models\LineItem;
 use craft\db\Query;
 use craft\db\Table;
 use craft\models\MatrixBlockType;
@@ -14,6 +15,8 @@ use yii\base\ErrorException;
 use yii\base\Event;
 use fostercommerce\shipstationconnect\Plugin;
 use fostercommerce\shipstationconnect\events\FindOrderEvent;
+use fostercommerce\shipstationconnect\records\Shipment as ShipmentRecord;
+use SimpleXMLElement;
 
 class OrdersController extends Controller
 {
@@ -143,7 +146,7 @@ class OrdersController extends Controller
 
         $num_pages = $this->paginateOrders($query);
 
-        $parent_xml = new \SimpleXMLElement('<Orders />');
+        $parent_xml = new SimpleXMLElement('<Orders />');
         $parent_xml->addAttribute('pages', $num_pages);
 
         Plugin::getInstance()->xml->orders($parent_xml, $query->all());
@@ -154,8 +157,8 @@ class OrdersController extends Controller
     /**
      * For a Criteria instance of Orders, return the number of total pages and apply a corresponding offset and limit
      *
-     * @param ElementCriteriaModel, a REFERENCE to the criteria instance
-     * @return Int total number of pages
+     * @param ElementCriteriaModel $query, a REFERENCE to the criteria instance
+     * @return int total number of pages
      */
     protected function paginateOrders(&$query)
     {
@@ -225,9 +228,7 @@ class OrdersController extends Controller
 
     /**
      * Updates order status for a given order. This is called by ShipStation.
-     * The order is found using the query param `order_number`.
-     *
-     * TODO: This assumes there is a "shipped" handle for an order status
+     * The order is found using the XML node OrderNumber.
      *
      * See craft/plugins/commerce/controllers/Commerce_OrdersController.php#actionUpdateStatus() for details
      *
@@ -235,20 +236,71 @@ class OrdersController extends Controller
      */
     protected function postShipment()
     {
-        $order = $this->orderFromParams();
+        $request = Craft::$app->getRequest();
+
+        $shipNotice = json_decode(json_encode(new SimpleXMLElement($request->getRawBody())));
+
+        $order = $this->orderFromBody($shipNotice);
 
         $settings = Plugin::getInstance()->settings;
 
-        $status = CommercePlugin::getInstance()
+        // Set default order status then change accordingly if saveShipmentItems is set
+        $orderStatusHandle = $settings->shippedStatusHandle;
+        if ($settings->saveShipmentItems) {
+            $lineItemStatuses = CommercePlugin::getInstance()->getLineItemStatuses();
+            $partiallyShipped = $lineItemStatuses
+                ->getLineItemStatusByHandle($settings->partiallyShippedLineItemStatusHandle);
+            $shipped = $lineItemStatuses
+                ->getLineItemStatusByHandle($settings->shippedLineItemStatusHandle);
+
+            $newQtys = [];
+            if (is_array($shipNotice->Items->Item)) {
+                foreach ($shipNotice->Items->Item as $item) {
+                    $newQtys[$item->SKU] = $item->Quantity;
+                }
+            } else {
+                $newQtys[$shipNotice->Items->Item->SKU] = $shipNotice->Items->Item->Quantity;
+            }
+
+            $shippedQtys = $this->getShippedQtys($order->id);
+
+            $shippedLineItems = 0;
+            $rows = [
+                'save' => [],
+                'update' => [],
+                'delete' => []
+            ];
+            foreach ($order->lineItems as $lineItem) {
+                if (isset($newQtys[$lineItem->sku])) {
+                    $status = $this->getNewLineItemStatus(
+                        $lineItem,
+                        $newQtys[$lineItem->sku],
+                        $shippedQtys[$lineItem->sku] ?? null
+                    );
+
+                    $lineItem->lineItemStatusId = $$status->id;
+                }
+
+                if ($lineItem->lineItemStatusId == $shipped->id) {
+                    $shippedLineItems++;
+                }
+            }
+
+            if ($shippedLineItems !== count($order->lineItems)) {
+                $orderStatusHandle = $settings->partiallyShippedStatusHandle;
+            }
+        }
+
+        $orderStatus = CommercePlugin::getInstance()
             ->orderStatuses
-            ->getOrderStatusByHandle($settings->shippedStatusHandle);
-        if (!$status) {
+            ->getOrderStatusByHandle($orderStatusHandle);
+        if (!$orderStatus) {
             throw new ErrorException("Failed to find shipped order status");
         }
 
-        $order->orderStatusId = $status->id;
+        $order->orderStatusId = $orderStatus->id;
         $order->message = 'Marking order as shipped. Adding shipping information.';
-        $shippingInformation = $this->getShippingInformationFromParams();
+        $shippingInformation = $this->getShippingInformationFromBody($shipNotice);
 
         $matrix = Craft::$app->fields->getFieldByHandle($settings->matrixFieldHandle);
 
@@ -262,11 +314,21 @@ class OrdersController extends Controller
                     'fieldId' => $matrix->id,
                     'typeId' => $blockType->id,
                 ]);
-                $block->setFieldValue($settings->carrierFieldHandle, $shippingInformation['carrier']);
-                $block->setFieldValue($settings->serviceFieldHandle, $shippingInformation['service']);
-                $block->setFieldValue($settings->trackingNumberFieldHandle, $shippingInformation['trackingNumber']);
+                $block->setFieldValues([
+                    $settings->carrierFieldHandle => $shippingInformation['carrier'],
+                    $settings->serviceFieldHandle => $shippingInformation['service'],
+                    $settings->trackingNumberFieldHandle => $shippingInformation['trackingNumber']
+                ]);
 
-                if (!Craft::$app->elements->saveElement($block)) {
+                if (Craft::$app->elements->saveElement($block)) {
+                    if ($settings->saveShipmentItems) {
+                        $shipment = new ShipmentRecord();
+                        $shipment->orderId = $order->id;
+                        $shipment->shipmentId = $block->getId();
+                        $shipment->shippedQtys = json_encode($newQtys);
+                        $shipment->save();
+                    }
+                } else {
                     Craft::warning(
                         Craft::t(
                             'shipstationconnect',
@@ -306,47 +368,48 @@ class OrdersController extends Controller
     }
 
     /**
-     * Parse parameters POSTed from ShipStation for fields available to us on the Order's shippingInfo matrix field
+     * Parse XML nodes POSTed from ShipStation for fields available to us on the Order's shippingInfo matrix field
      *
      * Note: only fields that exist in the matrix block will be set.
      *       ShipStation posts, in XML, many more fields than these, but for now we disregard.
      *       https://help.shipstation.com/hc/en-us/articles/205928478-ShipStation-Custom-Store-Development-Guide#2ai
      *
+     * @param object $body
      * @return array
      */
-    protected function getShippingInformationFromParams()
+    protected function getShippingInformationFromBody(object $body)
     {
-        $request = Craft::$app->getRequest();
+        // Test is_scalar to weed out empty properties converted to StdClass objects by json_encode
         return [
-            'carrier' => $request->getParam('carrier'),
-            'service' => $request->getParam('service'),
-            'trackingNumber' => $request->getParam('tracking_number'),
+            'carrier' => is_scalar($body->Carrier) ? $body->Carrier : '',
+            'service' => is_scalar($body->Service) ? $body->Service : '',
+            'trackingNumber' => is_scalar($body->TrackingNumber) ? $body->TrackingNumber : '',
         ];
     }
 
     /**
-     * Find the order model given the order_number passed to us from ShipStation.
+     * Find the order model given the OrderNumber passed to us from ShipStation.
      *
-     * Note: the order_number value from ShipStation corresponds to $order->number that we
+     * Note: the OrderNumber value from ShipStation corresponds to $order->number that we
      *       return to ShipStation as part of the getOrders() method above.
      *
+     * @param object $body
      * @throws HttpException, 404 if not found, 406 if order number is invalid
      * @return Commerce_Order
      */
-    protected function orderFromParams()
+    protected function orderFromBody(object $body)
     {
-        $request = Craft::$app->getRequest();
-        if ($orderNumber = $request->getParam('order_number')) {
-            $findOrderEvent = new FindOrderEvent(['orderNumber' => $orderNumber]);
+        if (isset($body->OrderNumber)) {
+            $findOrderEvent = new FindOrderEvent(['orderNumber' => $body->OrderNumber]);
             Event::trigger(static::class, self::FIND_ORDER_EVENT, $findOrderEvent);
 
             $order = $findOrderEvent->order;
             if (!$order) {
-                if ($order = Order::find()->reference($orderNumber)->one()) {
+                if ($order = Order::find()->reference($body->OrderNumber)->one()) {
                     return $order;
                 }
 
-                throw new HttpException(404, "Order with number '{$orderNumber}' not found");
+                throw new HttpException(404, "Order with number '{$body->OrderNumber}' not found");
             }
 
             return $order;
@@ -362,7 +425,7 @@ class OrdersController extends Controller
      * @param SimpleXMLElement $xml
      * @return null
      */
-    protected function returnXML(\SimpleXMLElement $xml)
+    protected function returnXML(SimpleXMLElement $xml)
     {
         header("Content-type: text/xml");
         // Output it into a buffer, in case TasksService wants to close the connection prematurely
@@ -370,5 +433,57 @@ class OrdersController extends Controller
         echo $xml->asXML();
 
         exit(0);
+    }
+
+    /**
+     * Returns whether line item status should use shipped or partiallyShipped status setting
+     *
+     * @param LineItem $lineItem
+     * @param int $newQty
+     * @param int|null $shippedQty
+     * @return string
+     */
+    protected function getNewLineItemStatus(LineItem $lineItem, int $newQty, ?int $shippedQty)
+    {
+        if ($shippedQty + $newQty === $lineItem->qty) {
+            return 'shipped';
+        }
+
+        return 'partiallyShipped';
+    }
+
+    /**
+     * Returns an array of all ShipmentRecords related to the order, keyed by line item ID
+     *
+     * @param int $orderId
+     * @return array
+     */
+    protected function getShippedQtys(int $orderId)
+    {
+        $records = ShipmentRecord::find()
+            ->where(['orderId' => $orderId])
+            ->all();
+
+        $qtys = [];
+        foreach ($records as $record) {
+            $qtys = array_merge_recursive($qtys, json_decode($record->shippedQtys, true));
+        }
+
+        return array_map([$this, 'sumQtys'], $qtys);
+    }
+
+    /**
+     * Returns sum of array, otherwise typecast int
+     *
+     * @param mixed $value
+     * @return int
+     */
+    protected function sumQtys($val)
+    {
+        if (gettype($val) === 'array') {
+            return array_sum($val);
+        }
+
+        return (int)$val;
     }
 }

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace fostercommerce\shipstationconnect\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+use craft\helpers\MigrationHelper;
+use craft\commerce\db\Table as CommerceTable;
+use fostercommerce\shipstationconnect\records\Shipment;
+
+/**
+ * Installation migration
+ */
+class Install extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->createTable(Shipment::TABLE, [
+            'id' => $this->primaryKey(),
+            'orderId' => $this->integer()->notNull(),
+            'shipmentId' => $this->integer()->notNull(),
+            'shippedQtys' => $this->longText(),
+            'dateCreated' => $this->dateTime()->notNull(),
+            'dateUpdated' => $this->dateTime()->notNull(),
+            'uid' => $this->uid()
+        ]);
+
+        $this->createIndex(null, Shipment::TABLE, 'orderId', false);
+        $this->createIndex(null, Shipment::TABLE, 'shipmentId', true);
+
+        $this->addForeignKey(null, Shipment::TABLE, ['orderId'], CommerceTable::ORDERS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Shipment::TABLE, ['shipmentId'], Table::MATRIXBLOCKS, ['id'], 'CASCADE');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        MigrationHelper::dropAllForeignKeysOnTable(Shipment::TABLE, $this);
+
+        $this->dropTableIfExists(Shipment::TABLE);
+
+        Craft::$app->projectConfig->remove('shipstationconnect');
+
+        return true;
+    }
+}

--- a/src/migrations/m210428_235053_shipments.php
+++ b/src/migrations/m210428_235053_shipments.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace fostercommerce\shipstationconnect\migrations;
+
+use Craft;
+use craft\db\Migration;
+use craft\db\Table;
+use craft\commerce\db\Table as CommerceTable;
+use fostercommerce\shipstationconnect\records\Shipment;
+
+/**
+ * m210428_235053_shipments migration.
+ */
+class m210428_235053_shipments extends Migration
+{
+    /**
+     * @inheritdoc
+     */
+    public function safeUp()
+    {
+        $this->createTable(Shipment::TABLE, [
+            'id' => $this->primaryKey(),
+            'orderId' => $this->integer()->notNull(),
+            'shipmentId' => $this->integer()->notNull(),
+            'shippedQtys' => $this->longText(),
+            'dateCreated' => $this->dateTime()->notNull(),
+            'dateUpdated' => $this->dateTime()->notNull(),
+            'uid' => $this->uid()
+        ]);
+
+        $this->createIndex(null, Shipment::TABLE, 'orderId', false);
+        $this->createIndex(null, Shipment::TABLE, 'shipmentId', true);
+
+        $this->addForeignKey(null, Shipment::TABLE, ['orderId'], CommerceTable::ORDERS, ['id'], 'CASCADE');
+        $this->addForeignKey(null, Shipment::TABLE, ['shipmentId'], Table::MATRIXBLOCKS, ['id'], 'CASCADE');
+
+        return true;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function safeDown()
+    {
+        echo "m210428_235053_shipments cannot be reverted.\n";
+        return false;
+    }
+}

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -11,11 +11,15 @@ class Settings extends Model
     public $shipstationPassword = '';
     public $ordersPageSize = 25;
     public $orderIdPrefix = '';
+    public $billingSameAsShipping = false;
     public $shippedStatusHandle = 'shipped';
+    public $saveShipmentItems = false;
+    public $partiallyShippedStatusHandle = '';
+    public $shippedLineItemStatusHandle = '';
+    public $partiallyShippedLineItemStatusHandle = '';
     public $matrixFieldHandle = 'shippingInfo';
     public $blockTypeHandle = 'shippingInfo';
     public $carrierFieldHandle = 'carrier';
     public $serviceFieldHandle = 'service';
     public $trackingNumberFieldHandle = 'trackingNumber';
-    public $billingSameAsShipping = false;
 }

--- a/src/records/Shipment.php
+++ b/src/records/Shipment.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace fostercommerce\shipstationconnect\records;
+
+use modules\sitemodule\SiteModule;
+
+use Craft;
+use craft\db\ActiveRecord;
+
+/**
+ * Parial Quantity Record
+ *
+ * @property int $orderId
+ * @property int $lineItemId
+ * @property int $qty
+ */
+class Shipment extends ActiveRecord
+{
+    const TABLE = '{{%shipstationconnect_shipments}}';
+
+    // Public Methods
+    // =========================================================================
+
+	/**
+	 * @inheritdoc
+	 */
+    public static function tableName(): string
+    {
+        return self::TABLE;
+    }
+}

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -186,6 +186,10 @@ class Xml extends Component
         $item_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
         $item_mapping = [
+            'LineItemID' => [
+                'field' => 'id',
+                'cdata' => false,
+            ],
             'SKU' => [
                 'callback' => function ($item) {
                     return $item->snapshot['sku'];
@@ -349,9 +353,9 @@ class Xml extends Component
 
         $names = [$firstName, $lastName];
         $names = array_filter(
-            $names, 
-            function($name) { 
-                return $name !== null && $name !== ''; 
+            $names,
+            function($name) {
+                return $name !== null && $name !== '';
             }
         );
 

--- a/src/templates/settings/index.twig
+++ b/src/templates/settings/index.twig
@@ -15,7 +15,7 @@
   <input type="hidden" name="action" value="shipstationconnect/settings/save">
   {{ redirectInput('shipstationconnect/settings') }}
   <div>
-      <h3>Custom Store</h3>
+      <h2>Custom Store Configuration</h2>
       <p>
           ShipStation's custom store integration works by requesting orders from ShipStation Connect (shipped and unshipped),
           and then by notifying ShipStation Connect when an order has been shipped.
@@ -83,7 +83,7 @@
   {% endif %}
   {% if isUsingCraftAuth %}
   <p class="error">
-    This site is using Craft's enableBasicHttpAuth feature. A dedicated user 
+    This site is using Craft's enableBasicHttpAuth feature. A dedicated user
     should be added to access ShipStation Connect.
   </p>
   {% endif %}
@@ -131,6 +131,15 @@
       errors: settings.getErrors('orderIdPrefix'),
   }) }}
 
+  {{ forms.lightSwitchField({
+      label: "Billing address same as shipping address"|t('shipstationconnect'),
+      instructions: "When billing address is missing, use the shipping address instead"|t('shipstationconnect'),
+      name: 'settings[billingSameAsShipping]',
+      on: settings.billingSameAsShipping,
+      checked: settings.billingSameAsShipping,
+      errors: settings.getErrors('billingSameAsShipping')
+  }) }}
+
   {% set statusHandles = craft.commerce.orderStatuses.getAllOrderStatuses %}
   {% set statusHandles = statusHandles|map(s => { label: s.name, value: s.handle }) %}
 
@@ -148,16 +157,54 @@
       </ul>
   </div>
 
-  <h2>Shipped Order Status</h2>
+  <hr>
+
+  <h2>Shipment Notification</h2>
 
   {{ forms.selectField({
-      label: 'Status Handle'|t('shipstationconnect'),
+      label: 'Shipped Status Handle'|t('shipstationconnect'),
       name: 'settings[shippedStatusHandle]',
       value: settings.shippedStatusHandle,
       options: statusHandles,
   }) }}
 
-  <h2>Shipping Info Matrix Field</h2>
+  {{ forms.lightSwitchField({
+      label: "Save shipment items"|t('shipstationconnect'),
+      instructions: "When enabled, ShipStation Connect will record line item quantities in each shipment and mark line item and order statuses as partially or fully shipped."|t('shipstationconnect'),
+      name: 'settings[saveShipmentItems]',
+      id: 'saveShipmentItems',
+      on: settings.saveShipmentItems,
+      checked: settings.saveShipmentItems,
+      errors: settings.getErrors('saveShipmentItems')
+  }) }}
+
+  <div id="status-handles"{% if not settings.saveShipmentItems %} class="hidden"{% endif %} style="margin-bottom: 24px;">
+    {% set lineItemStatusHandles = craft.commerce.lineItemStatuses.getAllLineItemStatuses() %}
+    {% set lineItemStatusHandles = lineItemStatusHandles|map(s => { label: s.name, value: s.handle }) %}
+
+    {{ forms.selectField({
+        label: 'Partially Shipped Status Handle'|t('shipstationconnect'),
+        name: 'settings[partiallyShippedStatusHandle]',
+        value: settings.partiallyShippedStatusHandle,
+        options: statusHandles,
+    }) }}
+
+    {{ forms.selectField({
+        label: 'Shipped Line Item Status Handle'|t('shipstationconnect'),
+        name: 'settings[shippedLineItemStatusHandle]',
+        value: settings.shippedLineItemStatusHandle,
+        options: lineItemStatusHandles
+    }) }}
+
+    {{ forms.selectField({
+        label: 'Partially Shipped Line Item Status Handle'|t('shipstationconnect'),
+        name: 'settings[partiallyShippedLineItemStatusHandle]',
+        value: settings.partiallyShippedLineItemStatusHandle,
+        options: lineItemStatusHandles
+    }) }}
+  </div>
+
+  <h3>Shipping Info Matrix Field</h3>
 
   {% set fields = craft.app.fields.allFields %}
   {% set fields = fields|filter(f => is_matrix(f))|map(f => { label: f.name, value: f.handle }) %}
@@ -211,13 +258,14 @@
       value: settings.trackingNumberFieldHandle,
       errors: settings.getErrors('trackingNumberFieldHandle'),
   }) }}
-
-  {{ forms.lightSwitchField({
-      label: "Billing address same as shipping address"|t('shipstationconnect'),
-      instructions: "When billing address is missing, use the shipping address instead"|t('shipstationconnect'),
-      name: 'settings[billingSameAsShipping]',
-      on: settings.billingSameAsShipping,
-      checked: settings.billingSameAsShipping,
-      errors: settings.getErrors('billingSameAsShipping')
-  }) }}
 {% endset %}
+
+{% js %}
+  $('#saveShipmentItems').on('change', function() {
+    if ($('[name="settings[saveShipmentItems]"]').val() == 1) {
+      $('#status-handles').removeClass('hidden');
+    } else {
+      $('#status-handles').addClass('hidden');
+    }
+  });
+{% endjs %}

--- a/src/variables/ShipstationConnectVariable.php
+++ b/src/variables/ShipstationConnectVariable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace fostercommerce\shipstationconnect\variables;
+
+use fostercommerce\shipstationconnect\records\Shipment;
+
+class ShipstationConnectVariable
+{
+    // Public Methods
+    // =========================================================================
+
+    public function getShipmentQtys(int $id)
+    {
+        return json_decode(Shipment::findOne(['shipmentId' => $id])->shippedQtys, true);
+    }
+}


### PR DESCRIPTION
Noticed that ShipStation posts an XML response with ship notices that include items and quantities shipped. We could really use this information on our end for multiple purposes, so I made the following feature to save those details. The _Save shipment items_ setting saves line item quantities for each shipment and updates the line items and order as partially or fully shipped as notices are pushed to ShipStation Connect. This information can be accessed in twig by passing a matrix block ID like this: 

```Twig
{% set qtys = craft.shipstationConnect.getShipmentQtys(order.shippingInfo.one().id) %}
```

Is this something you'd consider merging?