### PR TITLE
Craft 4/Commerce 4 version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.0.1 - 2022-07-19
+
+### Added
+
+- Support for Craft 4/Commerce 4. Note that development for Craft 3 has stopped at 1.3.7.
+
 ## 1.3.7 - 2021-12-01
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Craft CMS plugin for integrating Craft Commerce with ShipStation",
     "homepage": "https://github.com/fostercommerce/shipstation-connect",
     "type": "craft-plugin",
-    "version": "2.0",
+    "version": "2.0.1",
     "keywords": ["craft","plugin","shipstation"],
     "license": "proprietary",
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Craft CMS plugin for integrating Craft Commerce with ShipStation",
     "homepage": "https://github.com/fostercommerce/shipstation-connect",
     "type": "craft-plugin",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "keywords": ["craft","plugin","shipstation"],
     "license": "proprietary",
     "support": {
@@ -23,8 +23,8 @@
         }
       },
     "require": {
-        "craftcms/cms": "^3.0",
-        "craftcms/commerce": "^2.0|^3.0"
+        "craftcms/cms": "^4.0",
+        "craftcms/commerce": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A Craft CMS plugin for integrating Craft Commerce with ShipStation",
     "homepage": "https://github.com/fostercommerce/shipstation-connect",
     "type": "craft-plugin",
-    "version": "1.3.8",
+    "version": "2.0",
     "keywords": ["craft","plugin","shipstation"],
     "license": "proprietary",
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
       },
     "require": {
         "craftcms/cms": "^4.0",
-        "craftcms/commerce": "^2.0|^3.0|^4.0"
+        "craftcms/commerce": "^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.13"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -54,15 +54,18 @@ class Plugin extends \craft\base\Plugin
         // So we intercept the request and rename that parameter to ssaction IF the request is for one of this plugin's controllers
         Craft::$app->on(Application::EVENT_INIT, function() {
             $request = Craft::$app->request;
-            if(in_array('actions', $request->getSegments()) && in_array('shipstationconnect', $request->getSegments())) {
-                if(array_key_exists('action', $request->getQueryParams())) {
-                   // rename array key to match the action name
-                   $params = $request->getQueryParams();
-                   $params['ssaction'] = $params['action'];
-                   unset($params['action']);
-                   $request->setQueryParams($params);
-                }
-            };
+            if(!$request->isConsoleRequest){
+                if(in_array('actions', $request->getSegments()) && in_array('shipstationconnect', $request->getSegments())) {
+                    if(array_key_exists('action', $request->getQueryParams())) {
+                    // rename array key to match the action name
+                    $params = $request->getQueryParams();
+                    $params['ssaction'] = $params['action'];
+                    unset($params['action']);
+                    $request->setQueryParams($params);
+                    }
+                };
+            }
+          
            
         });
 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -4,6 +4,7 @@ namespace fostercommerce\shipstationconnect;
 use Craft;
 use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
+use craft\web\Application;
 use craft\services\UserPermissions;
 use craft\events\RegisterUserPermissionsEvent;
 use craft\base\Model;
@@ -47,6 +48,20 @@ class Plugin extends \craft\base\Plugin
         ]);
 
         Craft::$app->view->registerTwigExtension(new IsFieldTypeFilter());
+        
+        Craft::$app->on(Application::EVENT_INIT, function() {
+            $request = Craft::$app->request;
+            if(in_array('actions', $request->getSegments()) && in_array('shipstationconnect', $request->getSegments())) {
+                if(array_key_exists('action', $request->getQueryParams())) {
+                   // rename array key to match the action name
+                   $params = $request->getQueryParams();
+                   $params['ssaction'] = $params['action'];
+                   unset($params['action']);
+                   $request->setQueryParams($params);
+                }
+            };
+           
+        });
 
         Event::on(
             UrlManager::class,
@@ -56,6 +71,16 @@ class Plugin extends \craft\base\Plugin
                 $event->rules['shipstationconnect/settings/save'] = 'shipstationconnect/settings/save';
             }
         );
+        
+            
+        Event::on(
+            UrlManager::class,
+            UrlManager::EVENT_REGISTER_SITE_URL_RULES,
+            function (RegisterUrlRulesEvent $event) {
+                $event->rules['export'] = 'shipstationconnect/orders/export';
+            }
+        );
+    
 
         Event::on(
             UserPermissions::class, 

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -6,17 +6,39 @@ use craft\events\RegisterUrlRulesEvent;
 use craft\web\UrlManager;
 use craft\services\UserPermissions;
 use craft\events\RegisterUserPermissionsEvent;
+use craft\base\Model;
 use yii\base\Event;
 use yii\base\Exception;
 use fostercommerce\shipstationconnect\web\twig\filters\IsFieldTypeFilter;
 
 class Plugin extends \craft\base\Plugin
 {
-    public $hasCpSettings = true;
-    public $hasCpSection = true;
-    public $schemaVersion = '1.0.1';
+    /**
+     * @var		bool	$hasCpSettings
+     */
+    public bool $hasCpSettings = true;
+    
+    /**
+     * @var		bool	$hasCpSection
+     */
+    public bool $hasCpSection = true;
+    
+    /**
+     * @var		string	$schemaVersion
+     */
+    public string $schemaVersion = '1.0.1';
 
-    public function init()
+    
+    /**
+     * init.
+     *
+     * @author	Unknown
+     * @since	v0.0.1
+     * @version	v1.0.0	Monday, May 23rd, 2022.
+     * @access	public
+     * @return	void
+     */
+    public function init(): void
     {
         parent::init();
 
@@ -42,14 +64,14 @@ class Plugin extends \craft\base\Plugin
         });
     }
 
-    protected function beforeInstall(): bool
+    protected function beforeInstall(): void
     {
         if (!Craft::$app->plugins->isPluginInstalled('commerce')) {
             Craft::error(Craft::t(
                 'shipstationconnect',
                 'Failed to install. Craft Commerce is required.'
             ));
-            return false;
+            // return false;
         }
 
         if (!Craft::$app->plugins->isPluginEnabled('commerce')) {
@@ -57,13 +79,11 @@ class Plugin extends \craft\base\Plugin
                 'shipstationconnect',
                 'Failed to install. Craft Commerce is required.'
             ));
-            return false;
+           // return false;
         }
-
-        return true;
     }
 
-    public function getCpNavItem()
+    public function getCpNavItem(): ?array
     {
         $item = parent::getCpNavItem();
 
@@ -75,12 +95,12 @@ class Plugin extends \craft\base\Plugin
         return $item;
     }
 
-    protected function createSettingsModel()
+    protected function createSettingsModel(): ?Model
     {
         return new \fostercommerce\shipstationconnect\models\Settings();
     }
 
-    public function settingsHtml()
+    public function settingsHtml(): ?string
     {
         return Craft::$app->getView()->renderTemplate('shipstationconnect/settings', [
             'settings' => $this->getSettings()

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,11 +57,11 @@ class Plugin extends \craft\base\Plugin
             if(!$request->isConsoleRequest){
                 if(in_array('actions', $request->getSegments()) && in_array('shipstationconnect', $request->getSegments())) {
                     if(array_key_exists('action', $request->getQueryParams())) {
-                    // rename array key to match the action name
-                    $params = $request->getQueryParams();
-                    $params['ssaction'] = $params['action'];
-                    unset($params['action']);
-                    $request->setQueryParams($params);
+                        // rename array key to match the action name
+                        $params = $request->getQueryParams();
+                        $params['ssaction'] = $params['action'];
+                        unset($params['action']);
+                        $request->setQueryParams($params);
                     }
                 };
             }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -49,6 +49,9 @@ class Plugin extends \craft\base\Plugin
 
         Craft::$app->view->registerTwigExtension(new IsFieldTypeFilter());
         
+        // Because Shipstation uses a querystring parameter of 'action' in their requests. 
+        // This interferes with Craft's routing system. 
+        // So we intercept the request and rename that parameter to ssaction IF the request is for one of this plugin's controllers
         Craft::$app->on(Application::EVENT_INIT, function() {
             $request = Craft::$app->request;
             if(in_array('actions', $request->getSegments()) && in_array('shipstationconnect', $request->getSegments())) {

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -52,6 +52,7 @@ class Plugin extends \craft\base\Plugin
         // Because Shipstation uses a querystring parameter of 'action' in their requests. 
         // This interferes with Craft's routing system. 
         // So we intercept the request and rename that parameter to ssaction IF the request is for one of this plugin's controllers
+        /*
         Craft::$app->on(Application::EVENT_INIT, function() {
             $request = Craft::$app->request;
             if(!$request->isConsoleRequest){
@@ -68,6 +69,7 @@ class Plugin extends \craft\base\Plugin
           
            
         });
+        */
 
         Event::on(
             UrlManager::class,

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -57,11 +57,20 @@ class Plugin extends \craft\base\Plugin
             }
         );
 
-        Event::on(UserPermissions::class, UserPermissions::EVENT_REGISTER_PERMISSIONS, function(RegisterUserPermissionsEvent $event) {
-            $event->permissions['ShipStation Connect'] = [
-                'shipstationconnect-processOrders' => ['label' => 'Process Orders'],
-            ];
-        });
+        Event::on(
+            UserPermissions::class, 
+            UserPermissions::EVENT_REGISTER_PERMISSIONS, 
+            function(RegisterUserPermissionsEvent $event) {
+                $event->permissions[] = [
+                    'heading' => 'ShipStation Connect',
+                    'permissions' => [
+                        'shipstationconnect-processOrders' => [
+                                'label' => 'Process Orders'
+                        ],
+                    ]
+                ];
+            }
+        );
     }
 
     protected function beforeInstall(): void

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -42,7 +42,6 @@ class OrdersController extends Controller
         
         parent::init();
         
-        //return parent::init();
     }
 
     /**

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -15,6 +15,7 @@ use craft\models\MatrixBlockType;
 use yii\web\HttpException;
 use yii\base\ErrorException;
 use yii\base\Event;
+use yii\web\Response as YiiResponse;
 use fostercommerce\shipstationconnect\Plugin;
 use fostercommerce\shipstationconnect\events\FindOrderEvent;
 
@@ -53,7 +54,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $action = null): mixed
+    public function actionProcess($store = null, $action = null): null|string|Response|YiiResponse|SimpleXMLElement
     {
         $request = Craft::$app->request;
         try {

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -52,7 +52,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $do = null): mixed
+    public function actionProcess($store = null, $ssaction = null): mixed
     {
         $request = Craft::$app->request;
         try {
@@ -60,7 +60,7 @@ class OrdersController extends Controller
                 throw new HttpException(401, 'Invalid ShipStation username or password.');
             }
 
-            switch ($do) {
+            switch ($ssaction) {
                 case 'export':
                     return $this->getOrders($store);
                 case 'shipnotify':
@@ -69,19 +69,19 @@ class OrdersController extends Controller
                     throw new HttpException(400, 'No action set. Set the ?action= parameter as `export` or `shipnotify`.');
             }
         } catch (ErrorException $e) {
-            $this->logException('Error processing action {action}', ['action' => $do], $e);
+            $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
             return $this->asErrorJson($e->getMessage())->setStatusCode(500);
         } catch (HttpException $e) {
-            $action = $do;
-            if ($action) {
-                $this->logException('Error processing action {action}', ['action' => $action], $e);
+           
+            if ($ssaction) {
+                $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
             } else {
                 $this->logException('An action is required. Supported actions: export, shipnotify.');
             }
 
             return $this->asErrorJson($e->getMessage())->setStatusCode($e->statusCode);
         } catch (\Exception $e) {
-            $this->logException('Error processing action {action}', ['action' => $action], $e);
+            $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
             return $this->asErrorJson($e->getMessage())->setStatusCode(500);
         }
     }

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -10,6 +10,7 @@ use craft\commerce\elements\Order;
 use craft\db\Query;
 use craft\db\Table;
 use craft\helpers\App;
+use craft\web\Response;
 use craft\models\MatrixBlockType;
 use yii\web\HttpException;
 use yii\base\ErrorException;
@@ -238,7 +239,7 @@ class OrdersController extends Controller
      *
      * @throws ErrorException if the order fails to save
      */
-    protected function postShipment(): ?string
+    protected function postShipment(): null|string|Response
     {
         $order = $this->orderFromParams();
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -50,7 +50,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $action = null): void
+    public function actionProcess($store = null, $action = null): mixed
     {
         $request = Craft::$app->request;
         try {

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -52,7 +52,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $ssaction = null): mixed
+    public function actionProcess($store = null, $action = null): mixed
     {
         $request = Craft::$app->request;
         try {
@@ -60,7 +60,7 @@ class OrdersController extends Controller
                 throw new HttpException(401, 'Invalid ShipStation username or password.');
             }
 
-            switch ($ssaction) {
+            switch ($action) {
                 case 'export':
                     return $this->getOrders($store);
                 case 'shipnotify':
@@ -69,11 +69,11 @@ class OrdersController extends Controller
                     throw new HttpException(400, 'No action set. Set the ?action= parameter as `export` or `shipnotify`.');
             }
         } catch (ErrorException $e) {
-            $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
+            $this->logException('Error processing action {action}', ['action' => $action], $e);
             return $this->asErrorJson($e->getMessage())->setStatusCode(500);
         } catch (HttpException $e) {
            
-            if ($ssaction) {
+            if ($action) {
                 $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
             } else {
                 $this->logException('An action is required. Supported actions: export, shipnotify.');
@@ -81,7 +81,7 @@ class OrdersController extends Controller
 
             return $this->asErrorJson($e->getMessage())->setStatusCode($e->statusCode);
         } catch (\Exception $e) {
-            $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
+            $this->logException('Error processing action {action}', ['action' => $action], $e);
             return $this->asErrorJson($e->getMessage())->setStatusCode(500);
         }
     }

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -53,7 +53,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $action = null): mixed
+    public function actionProcess($store = null, $do = null): mixed
     {
         $request = Craft::$app->request;
         try {
@@ -61,7 +61,7 @@ class OrdersController extends Controller
                 throw new HttpException(401, 'Invalid ShipStation username or password.');
             }
 
-            switch ($action) {
+            switch ($do) {
                 case 'export':
                     return $this->getOrders($store);
                 case 'shipnotify':
@@ -70,10 +70,10 @@ class OrdersController extends Controller
                     throw new HttpException(400, 'No action set. Set the ?action= parameter as `export` or `shipnotify`.');
             }
         } catch (ErrorException $e) {
-            $this->logException('Error processing action {action}', ['action' => $action], $e);
+            $this->logException('Error processing action {action}', ['action' => $do], $e);
             return $this->asErrorJson($e->getMessage())->setStatusCode(500);
         } catch (HttpException $e) {
-            $action = $action;
+            $action = $do;
             if ($action) {
                 $this->logException('Error processing action {action}', ['action' => $action], $e);
             } else {

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -74,7 +74,7 @@ class OrdersController extends Controller
         } catch (HttpException $e) {
            
             if ($action) {
-                $this->logException('Error processing action {action}', ['action' => $ssaction], $e);
+                $this->logException('Error processing action {action}', ['action' => $action], $e);
             } else {
                 $this->logException('An action is required. Supported actions: export, shipnotify.');
             }

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -9,6 +9,7 @@ use craft\commerce\Plugin as CommercePlugin;
 use craft\commerce\elements\Order;
 use craft\db\Query;
 use craft\db\Table;
+use craft\helpers\App;
 use craft\models\MatrixBlockType;
 use yii\web\HttpException;
 use yii\base\ErrorException;
@@ -111,8 +112,8 @@ class OrdersController extends Controller
         }
 
         $settings = $plugin->settings;
-        $expectedUsername = Craft::parseEnv($settings->shipstationUsername);
-        $expectedPassword = Craft::parseEnv($settings->shipstationPassword);
+        $expectedUsername = App::parseEnv($settings->shipstationUsername);
+        $expectedPassword = App::parseEnv($settings->shipstationPassword);
 
         list($username, $password) = Craft::$app->getRequest()->getAuthCredentials();
 

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -21,14 +21,14 @@ class OrdersController extends Controller
     const FIND_ORDER_EVENT = 'findOrderEvent';
 
     // Disable CSRF validation for the entire controller
-    public bool $enableCsrfValidation = false;
+    public $enableCsrfValidation = false;
 
-    protected bool $allowAnonymous = true;
+    protected array|int|bool $allowAnonymous = true;
 
     /**
      * @inheritDoc
      */
-    public function init()
+    public function init(): void
     {
         // Allow anonymous access only when this plugin is handling basic
         // authentication, otherwise require auth so that Craft doesn't let
@@ -38,8 +38,10 @@ class OrdersController extends Controller
         if ($isUsingCraftAuth) {
             $this->requirePermission('shipstationconnect-processOrders');
         }
-
-        return parent::init();
+        
+        parent::init();
+        
+        //return parent::init();
     }
 
     /**

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -336,9 +336,9 @@ class OrdersController extends Controller
      *       return to ShipStation as part of the getOrders() method above.
      *
      * @throws HttpException, 404 if not found, 406 if order number is invalid
-     * @return Commerce_Order
+     * @return Order
      */
-    protected function orderFromParams(): Commerce_Order
+    protected function orderFromParams(): Order
     {
         $request = Craft::$app->getRequest();
         if ($orderNumber = $request->getParam('order_number')) {

--- a/src/controllers/OrdersController.php
+++ b/src/controllers/OrdersController.php
@@ -21,9 +21,9 @@ class OrdersController extends Controller
     const FIND_ORDER_EVENT = 'findOrderEvent';
 
     // Disable CSRF validation for the entire controller
-    public $enableCsrfValidation = false;
+    public bool $enableCsrfValidation = false;
 
-    protected $allowAnonymous = true;
+    protected bool $allowAnonymous = true;
 
     /**
      * @inheritDoc
@@ -50,7 +50,7 @@ class OrdersController extends Controller
      * @param array $variables, containing key 'fulfillmentService'
      * @throws HttpException for malformed requests
      */
-    public function actionProcess($store = null, $action = null)
+    public function actionProcess($store = null, $action = null): void
     {
         $request = Craft::$app->request;
         try {
@@ -84,7 +84,7 @@ class OrdersController extends Controller
         }
     }
 
-    private function logException($msg, $params = [], $e = null)
+    private function logException($msg, $params = [], $e = null): void
     {
         Craft::error(
             Craft::t('shipstationconnect', $msg, $params),
@@ -101,7 +101,7 @@ class OrdersController extends Controller
      *
      * @return bool, true if successfully authenticated or false otherwise
      */
-    protected function authenticate()
+    protected function authenticate(): bool
     {
         $plugin = Plugin::getInstance();
         if ($plugin->isAuthHandledByCraft()) {
@@ -122,7 +122,7 @@ class OrdersController extends Controller
      *
      * @return SimpleXMLElement Orders XML
      */
-    protected function getOrders($store = null)
+    protected function getOrders($store = null): SimpleXMLElement
     {
         $query = Order::find();
 
@@ -160,7 +160,7 @@ class OrdersController extends Controller
      * @param ElementCriteriaModel, a REFERENCE to the criteria instance
      * @return Int total number of pages
      */
-    protected function paginateOrders(&$query)
+    protected function paginateOrders(&$query): int
     {
         $pageSize = Plugin::getInstance()->settings->ordersPageSize;
         if (!is_numeric($pageSize) || $pageSize < 1) {
@@ -185,7 +185,7 @@ class OrdersController extends Controller
      * @param String $field_name, the name of the field in GET params
      * @return String|null the formatted date string
      */
-    protected function parseDate($field_name)
+    protected function parseDate($field_name): ?string
     {
         $request = Craft::$app->getRequest();
         if ($date_raw = $request->getParam($field_name)) {
@@ -201,7 +201,7 @@ class OrdersController extends Controller
         return null;
     }
 
-    private function getBlockTypeByHandle($fieldId, $handle)
+    private function getBlockTypeByHandle($fieldId, $handle): ?MatrixBlockType
     {
         $result = (new Query())
             ->select([
@@ -236,7 +236,7 @@ class OrdersController extends Controller
      *
      * @throws ErrorException if the order fails to save
      */
-    protected function postShipment()
+    protected function postShipment(): ?string
     {
         $order = $this->orderFromParams();
 
@@ -296,7 +296,7 @@ class OrdersController extends Controller
         }
     }
 
-    private function validateShippingInformation($info)
+    private function validateShippingInformation($info): bool
     {
         // Requires at least one value
         foreach ($info as $key => $value) {
@@ -317,7 +317,7 @@ class OrdersController extends Controller
      *
      * @return array
      */
-    protected function getShippingInformationFromParams()
+    protected function getShippingInformationFromParams(): array
     {
         $request = Craft::$app->getRequest();
         return [
@@ -336,7 +336,7 @@ class OrdersController extends Controller
      * @throws HttpException, 404 if not found, 406 if order number is invalid
      * @return Commerce_Order
      */
-    protected function orderFromParams()
+    protected function orderFromParams(): Commerce_Order
     {
         $request = Craft::$app->getRequest();
         if ($orderNumber = $request->getParam('order_number')) {
@@ -365,7 +365,7 @@ class OrdersController extends Controller
      * @param SimpleXMLElement $xml
      * @return null
      */
-    protected function returnXML(\SimpleXMLElement $xml)
+    protected function returnXML(\SimpleXMLElement $xml): void
     {
         header("Content-type: text/xml");
         // Output it into a buffer, in case TasksService wants to close the connection prematurely

--- a/src/controllers/SettingsController.php
+++ b/src/controllers/SettingsController.php
@@ -7,10 +7,12 @@ use craft\db\Query;
 use fostercommerce\shipstationconnect\Plugin;
 use fostercommerce\shipstationconnect\models\Settings;
 
+use yii\web\Response;
+
 class SettingsController extends Controller
 {
 
-    public function actionIndex()
+    public function actionIndex(): Response
     {
         $plugin = Plugin::getInstance();
         return $this->renderTemplate("shipstationconnect/settings/index", [
@@ -19,7 +21,7 @@ class SettingsController extends Controller
         ]);
     }
 
-    public function actionSave()
+    public function actionSave(): Response
     {
         $this->requirePostRequest();
         $postData = Craft::$app->getRequest()->getBodyParam('settings');

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -8,7 +8,6 @@ use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
 use craft\commerce\models\Customer;
 use craft\commerce\models\Address;
-use craft\elements\User;
 use yii\base\Component;
 use yii\base\Event;
 
@@ -332,7 +331,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Customer'
      * @return SimpleXMLElement
      */
-    public function customer(\SimpleXMLElement $xml, User $customer, $name='Customer'): \SimpleXMLElement
+    public function customer(\SimpleXMLElement $xml, Customer $customer, $name='Customer'): \SimpleXMLElement
     {
         $customer_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -6,8 +6,10 @@ use fostercommerce\shipstationconnect\events\OrderFieldEvent;
 use craft\commerce\Plugin as CommercePlugin;
 use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
-use craft\commerce\models\Customer;
-use craft\commerce\models\Address;
+//use craft\commerce\models\Customer;
+//use craft\commerce\models\Address;
+use craft\elements\User;
+use craft\elements\Address;
 use yii\base\Component;
 use yii\base\Event;
 
@@ -331,7 +333,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Customer'
      * @return SimpleXMLElement
      */
-    public function customer(\SimpleXMLElement $xml, Customer $customer, $name='Customer'): \SimpleXMLElement
+    public function customer(\SimpleXMLElement $xml, User $customer, $name='Customer'): \SimpleXMLElement
     {
         $customer_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
@@ -366,7 +368,7 @@ class Xml extends Component
      * @param Customer $customer
      * @return SimpleXMLElement, or null if no address exists
      */
-    public function billTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer): ?SimpleXMLElement
+    public function billTo(\SimpleXMLElement $customer_xml, Order $order, User $customer): ?\SimpleXMLElement
     {
         $billingAddress = $order->getBillingAddress();
         if (!$billingAddress) {
@@ -380,7 +382,8 @@ class Xml extends Component
         if ($billingAddress) {
             $billTo_xml = $this->address($customer_xml, $billingAddress, 'BillTo');
             if (!$name = $this->generateName($billingAddress->firstName, $billingAddress->lastName)) {
-                $user = $customer->getUser();
+                //$user = $customer->getUser();
+                $user = $customer;
                 if ($user) {
                     $name = $this->generateName($user->firstName, $user->lastName) ?: 'Unknown';
                 } else {
@@ -403,12 +406,13 @@ class Xml extends Component
      * @param Customer $customer
      * @return SimpleXMLElement, or null if no address exists
      */
-    public function shipTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer): ?SimpleXMLElement
+    public function shipTo(\SimpleXMLElement $customer_xml, Order $order, User $customer): ?\SimpleXMLElement
     {
         $shippingAddress = $order->getShippingAddress();
         $shipTo_xml = $this->address($customer_xml, $shippingAddress, 'ShipTo');
         if (!$name = $this->generateName($shippingAddress->firstName, $shippingAddress->lastName)) {
-            $user = $customer->getUser();
+            //$user = $customer->getUser();
+            $user = $customer;
             if ($user) {
                 $name = $this->generateName($user->firstName, $user->lastName) ?: 'Unknown';
             } else {
@@ -434,19 +438,21 @@ class Xml extends Component
 
         if (!is_null($address)) {
             $address_mapping = [
-                'Company' => 'businessName',
-                'Phone' => 'phone',
-                'Address1' => 'address1',
-                'Address2' => 'address2',
-                'City' => 'city',
-                'State' => 'stateText',
-                'PostalCode' => 'zipCode',
-                'Country' =>  [
+                'Company' => 'organization',
+                //'Phone' => 'phone',
+                'Address1' => 'addressLine1',
+                'Address2' => 'addressLine2',
+                'City' => 'locality',
+                'State' => 'administrativeArea',
+                'PostalCode' => 'postalCode',
+                /*'Country' =>  [
                     'callback' => function ($address) {
                         return $address->countryId ? $address->getCountry()->iso : null;
                     },
                     'cdata' => false,
                 ]
+                */
+                'Country' => 'countryCode'
             ];
             $this->mapCraftModel($address_xml, $address_mapping, $address);
         }

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -8,6 +8,7 @@ use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
 use craft\commerce\models\Customer;
 use craft\commerce\models\Address;
+use craft\models\User;
 use yii\base\Component;
 use yii\base\Event;
 
@@ -331,7 +332,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Customer'
      * @return SimpleXMLElement
      */
-    public function customer(\SimpleXMLElement $xml, Customer $customer, $name='Customer'): \SimpleXMLElement
+    public function customer(\SimpleXMLElement $xml, User $customer, $name='Customer'): \SimpleXMLElement
     {
         $customer_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -16,7 +16,7 @@ class Xml extends Component
     const LINEITEM_OPTION_LIMIT = 10;
     const ORDER_FIELD_EVENT = 'orderFieldEvent';
 
-    public function shouldInclude($order)
+    public function shouldInclude($order): bool
     {
         $settings = Plugin::getInstance()->settings;
         $billingSameAsShipping = $settings->billingSameAsShipping;
@@ -34,7 +34,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Orders'
      * @return SimpleXMLElement
      */
-    public function orders(\SimpleXMLElement $xml, $orders, $name='Orders')
+    public function orders(\SimpleXMLElement $xml, $orders, $name='Orders'): \SimpleXMLElement
     {
         $orders_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
         foreach ($orders as $order) {
@@ -54,7 +54,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Order'
      * @return SimpleXMLElement
      */
-    public function order(\SimpleXMLElement $xml, Order $order, $name='Order')
+    public function order(\SimpleXMLElement $xml, Order $order, $name='Order'): \SimpleXMLElement
     {
         $order_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
@@ -140,7 +140,7 @@ class Xml extends Component
      * @param [Order] $order
      * @return null
      */
-    public function shippingMethod(\SimpleXMLElement $order_xml, $order)
+    public function shippingMethod(\SimpleXMLElement $order_xml, $order): void
     {
         $orderFieldEvent = new OrderFieldEvent([
             'field' => OrderFieldEvent::FIELD_SHIPPING_METHOD,
@@ -163,7 +163,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Items'
      * @return SimpleXMLElement
      */
-    public function items(\SimpleXMLElement $xml, $items, $name='Items')
+    public function items(\SimpleXMLElement $xml, $items, $name='Items'): \SimpleXMLElement
     {
         $items_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
         foreach ($items as $item) {
@@ -181,7 +181,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Item'
      * @return SimpleXMLElement
      */
-    public function item(\SimpleXMLElement $xml, LineItem $item, $name='Item')
+    public function item(\SimpleXMLElement $xml, LineItem $item, $name='Item'): \SimpleXMLElement
     {
         $item_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
@@ -248,7 +248,7 @@ class Xml extends Component
      * @param  string                 $name [description]
      * @return [type]                       [description]
      */
-    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item')
+    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item'): ?SimpleXMLElement
     {
         // If no discount was applied, skip this
         if ($order->getTotalDiscount() >= 0) {
@@ -297,7 +297,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Options'
      * @return SimpleXMLElement
      */
-    public function options(\SimpleXMLElement $xml, $options, $name='Options')
+    public function options(\SimpleXMLElement $xml, $options, $name='Options'): \SimpleXMLElement
     {
         $options_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
@@ -331,7 +331,7 @@ class Xml extends Component
      * @param String $name the name of the child node, default 'Customer'
      * @return SimpleXMLElement
      */
-    public function customer(\SimpleXMLElement $xml, Customer $customer, $name='Customer')
+    public function customer(\SimpleXMLElement $xml, Customer $customer, $name='Customer'): \SimpleXMLElement
     {
         $customer_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);
 
@@ -341,7 +341,7 @@ class Xml extends Component
         return $customer_xml;
     }
 
-    private function generateName($firstName, $lastName)
+    private function generateName($firstName, $lastName): ?string
     {
         if (!$firstName && !$lastName) {
             return false;
@@ -366,7 +366,7 @@ class Xml extends Component
      * @param Customer $customer
      * @return SimpleXMLElement, or null if no address exists
      */
-    public function billTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer)
+    public function billTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer): ?SimpleXMLElement
     {
         $billingAddress = $order->getBillingAddress();
         if (!$billingAddress) {
@@ -403,7 +403,7 @@ class Xml extends Component
      * @param Customer $customer
      * @return SimpleXMLElement, or null if no address exists
      */
-    public function shipTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer)
+    public function shipTo(\SimpleXMLElement $customer_xml, Order $order, Customer $customer): ?SimpleXMLElement
     {
         $shippingAddress = $order->getShippingAddress();
         $shipTo_xml = $this->address($customer_xml, $shippingAddress, 'ShipTo');

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -8,7 +8,7 @@ use craft\commerce\elements\Order;
 use craft\commerce\models\LineItem;
 use craft\commerce\models\Customer;
 use craft\commerce\models\Address;
-use craft\models\User;
+use craft\elements\User;
 use yii\base\Component;
 use yii\base\Event;
 

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -248,11 +248,11 @@ class Xml extends Component
      * @param  string                 $name [description]
      * @return [type]                       [description]
      */
-    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item'): ?SimpleXMLElement
+    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item'): mixed
     {
         // If no discount was applied, skip this
         if ($order->getTotalDiscount() >= 0) {
-            return;
+            return null;
         }
 
         $discount_xml = $xml->getName() == $name ? $xml : $xml->addChild($name);

--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -250,7 +250,7 @@ class Xml extends Component
      * @param  string                 $name [description]
      * @return [type]                       [description]
      */
-    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item'): mixed
+    public function discount(\SimpleXMLElement $xml, Order $order, $name='Item'): null|\SimpleXMLElement
     {
         // If no discount was applied, skip this
         if ($order->getTotalDiscount() >= 0) {

--- a/src/web/twig/filters/IsFieldTypeFilter.php
+++ b/src/web/twig/filters/IsFieldTypeFilter.php
@@ -5,27 +5,30 @@ use Craft;
 use craft\base\Field;
 use craft\fields\Matrix;
 use craft\fields\Dropdown;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
 
-class IsFieldTypeFilter extends \Twig_Extension
+class IsFieldTypeFilter extends AbstractExtension
 {
-    public function getName()
+    public function getName(): string
     {
         return 'IsMatrixFilter';
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
-            new \Twig_SimpleFilter('is_matrix', [$this, 'is_matrix']),
-            new \Twig_SimpleFilter('is_dropdown', [$this, 'is_dropdown']),
+            new TwigFilter('is_matrix', [$this, 'is_matrix']),
+            new TwigFilter('is_dropdown', [$this, 'is_dropdown']),
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
-            new \Twig_SimpleFunction('is_matrix', [$this, 'is_matrix']),
-            new \Twig_SimpleFunction('is_dropdown', [$this, 'is_dropdown']),
+            new TwigFunction('is_matrix', [$this, 'is_matrix']),
+            new TwigFunction('is_dropdown', [$this, 'is_dropdown']),
         ];
     }
 


### PR DESCRIPTION
Update the plugin to support Craft 4/Commerce 4.
This version will not be installable on Craft 3 and  has composer requirements indicating that Craft 4 and Commerce 4 are needed

When installing for Craft 3, version 1.3.7 will be installed.