### PR TITLE
fix: Remove shipping method lookup

### DIFF
--- a/src/services/Xml.php
+++ b/src/services/Xml.php
@@ -150,8 +150,8 @@ class Xml extends Component
         ]);
         Event::trigger(static::class, self::ORDER_FIELD_EVENT, $orderFieldEvent);
 
-        if (!$orderFieldEvent->value && $shippingMethod = $order->getShippingMethod()) {
-            $orderFieldEvent->value = $shippingMethod->handle;
+        if (!$orderFieldEvent->value) {
+            $orderFieldEvent->value = $order->shippingMethodHandle;
         }
 
         $this->addChildWithCDATA($order_xml, 'ShippingMethod', $orderFieldEvent->value);


### PR DESCRIPTION
The plugin only uses the shipping method handle when generating the XML document. This change removes the shipping method lookup and instead sets the field value to whatever shipping method handle is saved for the order.